### PR TITLE
Jtfs core

### DIFF
--- a/kymatio/scattering1d/backend/torch_backend.py
+++ b/kymatio/scattering1d/backend/torch_backend.py
@@ -136,6 +136,10 @@ class TorchBackend1D(TorchBackend):
         return x.squeeze(-1)
 
     @classmethod
+    def mean(cls, x):
+        return torch.mean(x, dim=-2, keepdim=True)
+
+    @classmethod
     def transpose(cls, x):
         return torch.transpose(x, dim0=-2, dim1=-3).contiguous()
 

--- a/kymatio/scattering1d/backend/torch_backend.py
+++ b/kymatio/scattering1d/backend/torch_backend.py
@@ -128,9 +128,15 @@ class TorchBackend1D(TorchBackend):
         return _ifft(x)
 
     @classmethod
-    def transpose(cls, x):
-        cls.complex_check(x)
+    def to_real(cls, x):
+        return x.unsqueeze(-1)
 
-        return torch.transpose(x, dim0=-2, dim1=-3)
+    @classmethod
+    def real_out(cls, x):
+        return x.squeeze(-1)
+
+    @classmethod
+    def transpose(cls, x):
+        return torch.transpose(x, dim0=-2, dim1=-3).contiguous()
 
 backend = TorchBackend1D

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -1,0 +1,8 @@
+
+def timefrequency_scattering(x, pad, unpad, backend, J, J_fr, psi1, psi2, phi, 
+                             psi_fr, pad_left=0,pad_right=0, ind_start=None, 
+                             ind_end=None, oversampling=0, size_scattering=(0, 0, 0), 
+                             out_type='array'):
+    pass
+
+

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -1,8 +1,126 @@
-
+import math 
 def timefrequency_scattering(x, pad, unpad, backend, J, J_fr, psi1, psi2, phi, 
-                             psi_fr, pad_left=0,pad_right=0, ind_start=None, 
+                             psi_fr, phi_fr, pad_left=0,pad_right=0, ind_start=None, 
                              ind_end=None, oversampling=0, size_scattering=(0, 0, 0), 
                              out_type='array'):
-    pass
+
+    subsample_fourier = backend.subsample_fourier
+    transpose = backend.transpose
+    modulus = backend.modulus
+    rfft = backend.rfft
+    ifft = backend.ifft
+    irfft = backend.irfft
+    cdgmm = backend.cdgmm
+    concatenate = backend.concatenate
+    to_real = backend.to_real
+    real_out = backend.real_out 
+
+    U_0 = pad(x, pad_left, pad_right)
+    U_0_hat = rfft(U_0)
+
+    # good spot to print shapes
+    U_1_list = []
+    S_1_T_list = []
+    for n1 in range(len(psi1)):
+        j1 = psi1[n1]['j']
+        k1 = max(j1 - oversampling, 0)
+
+        U_1_c = cdgmm(U_0_hat, psi1[n1][0])
+        U_1_hat = subsample_fourier(U_1_c, 2**k1)
+        U_1_c = ifft(U_1_hat)
+
+        U_1_m = modulus(U_1_c)
+        U_1_hat = rfft(U_1_m)
+
+        U_1_list.append(U_1_hat)
+
+        k1_J = max(J - k1 - oversampling, 0)
+
+        #TODO add if statement for T=None, int, 'global'
+        S_1_c = cdgmm(U_1_hat, phi[k1])
+        S_1_hat = subsample_fourier(S_1_c, 2**k1_J)
+        S_1_r = irfft(S_1_hat)
+
+        S_1_T = unpad(S_1_r, ind_start[k1_J + k1], ind_end[k1_J + k1])
+        # good spot to print shapes
+        S_1_T_list.append(S_1_T)
+
+    total_height = 2 ** math.ceil(1+math.log2(len(psi1)))
+    padding_row = 0 * S_1_T
+    for n1 in range(total_height - len(S_1_T_list)):
+        S_1_T_list.append(padding_row)
+    S_1_TM = to_real(concatenate(S_1_T_list))
+
+    k_fr_J = max(J_fr - oversampling, 0)
+    S_1_TM_T = transpose(S_1_TM)
+    S_1_TM_T_hat = rfft(S_1_TM_T)
+    S_1_TM_T_c = cdgmm(S_1_TM_T_hat, phi_fr[0])
+    S_1_TM_T_hat = subsample_fourier(S_1_TM_T_c, 2**k_fr_J)
+    S_1_TM_T = irfft(S_1_TM_T_hat)
+    S_1_FR = transpose(S_1_TM_T)
+    S_1_FR = real_out(S_1_FR)
+    # good spot to print shapes
+
+    S_2_list = []
+    for n2 in range(len(psi2)):
+        j2 = psi2[n2]['j']
+        if j2 == 0:
+            continue
+        U_2_list = []
+
+        for n1 in range(len(psi1)):
+            j1 = psi1[n1]['j']
+            if j1 >= j2:
+                continue
+            k1 = max(j1 - oversampling, 0)
+            k2 = max(j2 - j1 - oversampling, 0)
+
+            U_1_hat = U_1_list[n1]
+
+            U_2_c = cdgmm(U_1_hat, psi2[n2][k1])
+            U_2_hat = subsample_fourier(U_2_c, 2**k2)
+            U_2_c = ifft(U_2_hat)
+            U_2_list.append(U_2_c)
+            # good spot to print shapes
+
+        padding_row = 0 * U_2_c 
+        for n in range(total_height - len(U_2_list)):
+            U_2_list.append(padding_row)
+        U_2 = concatenate(U_2_list)
+
+        U_2_T = transpose(U_2)
+        U_2_hat_T = ifft(U_2_T)
+        # good spot to print shapes
+        
+        for n_fr in range(len(psi_fr)):
+            j_fr = psi_fr[n_fr]['j']
+            k_fr = max(j_fr - oversampling, 0)
+            U_fr_c = cdgmm(U_2_hat_T, psi_fr[n_fr][0])
+            U_fr_hat = subsample_fourier(U_fr_c, 2**k_fr)
+
+            U_2_m = modulus(U_fr_hat)
+            
+            k_J_fr = max(J_fr  - k_fr - oversampling, 0)
+            U_2_hat = rfft(U_2_m)
+            S_2_fr_c = cdgmm(U_2_hat, phi_fr[k_fr])
+            S_2_fr_hat = subsample_fourier(S_2_fr_c, 2**k_J_fr)
+            S_2_fr = irfft(S_2_fr_hat)
+            S_2_fr = transpose(S_2_fr)
+
+            k2_J = max(J - j2 - oversampling, 0)
+            U_2_hat = rfft(S_2_fr)
+            S_2_c = cdgmm(U_2_hat, phi[j2])
+            S_2_hat = subsample_fourier(S_2_c, 2 ** k2_J)
+            S_2_r = irfft(S_2_hat)
+            S_2 = unpad(S_2_r, ind_start[k2_J+k2+k1], ind_end[k2_J+k2+k1])
+            # good spot to print shapes
+            S_2_list.append(S_2)
+
+    out_S = []
+    out_S.extend([S_1_FR])
+    out_S.extend(S_2_list)
+    out_S = concatenate(out_S)
+    # good spot to print shapes
+    return out_S
 
 

--- a/kymatio/scattering1d/core/timefrequency_scattering.py
+++ b/kymatio/scattering1d/core/timefrequency_scattering.py
@@ -1,12 +1,13 @@
 import math 
 def timefrequency_scattering(x, pad, unpad, backend, J, J_fr, psi1, psi2, phi, 
-                             psi_fr, phi_fr, pad_left=0,pad_right=0, ind_start=None, 
+                             psi_fr, phi_fr, T="global", pad_left=0,pad_right=0, ind_start=None, 
                              ind_end=None, oversampling=0, size_scattering=(0, 0, 0), 
                              out_type='array'):
 
     subsample_fourier = backend.subsample_fourier
     transpose = backend.transpose
     modulus = backend.modulus
+    mean = backend.mean
     rfft = backend.rfft
     ifft = backend.ifft
     irfft = backend.irfft
@@ -36,13 +37,16 @@ def timefrequency_scattering(x, pad, unpad, backend, J, J_fr, psi1, psi2, phi,
 
         k1_J = max(J - k1 - oversampling, 0)
 
-        #TODO add if statement for T=None, int, 'global'
-        S_1_c = cdgmm(U_1_hat, phi[k1])
-        S_1_hat = subsample_fourier(S_1_c, 2**k1_J)
-        S_1_r = irfft(S_1_hat)
+        if T == "global":
+            S_1_T = mean(U_1_m)
+            S_1_T = real_out(S_1_T)
+        else:
+            S_1_c = cdgmm(U_1_hat, phi[k1])
+            S_1_hat = subsample_fourier(S_1_c, 2**k1_J)
+            S_1_r = irfft(S_1_hat)
 
-        S_1_T = unpad(S_1_r, ind_start[k1_J + k1], ind_end[k1_J + k1])
-        # good spot to print shapes
+            S_1_T = unpad(S_1_r, ind_start[k1_J + k1], ind_end[k1_J + k1])
+            # good spot to print shapes
         S_1_T_list.append(S_1_T)
 
     total_height = 2 ** math.ceil(1+math.log2(len(psi1)))
@@ -107,17 +111,21 @@ def timefrequency_scattering(x, pad, unpad, backend, J, J_fr, psi1, psi2, phi,
             S_2_fr = irfft(S_2_fr_hat)
             S_2_fr = transpose(S_2_fr)
 
-            k2_J = max(J - j2 - oversampling, 0)
-            U_2_hat = rfft(S_2_fr)
-            S_2_c = cdgmm(U_2_hat, phi[j2])
-            S_2_hat = subsample_fourier(S_2_c, 2 ** k2_J)
-            S_2_r = irfft(S_2_hat)
-            S_2 = unpad(S_2_r, ind_start[k2_J+k2+k1], ind_end[k2_J+k2+k1])
+            if T == "global":
+                S_2 = mean(S_2_fr)
+                S_2 = real_out(S_2)
+            else:
+                k2_J = max(J - j2 - oversampling, 0)
+                U_2_hat = rfft(S_2_fr)
+                S_2_c = cdgmm(U_2_hat, phi[j2])
+                S_2_hat = subsample_fourier(S_2_c, 2 ** k2_J)
+                S_2_r = irfft(S_2_hat)
+                S_2 = unpad(S_2_r, ind_start[k2_J+k2+k1], ind_end[k2_J+k2+k1])
             # good spot to print shapes
             S_2_list.append(S_2)
 
     out_S = []
-    out_S.extend([S_1_FR])
+    #out_S.extend([S_1_FR])
     out_S.extend(S_2_list)
     out_S = concatenate(out_S)
     # good spot to print shapes

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -197,12 +197,16 @@ class TimeFrequencyScatteringTorch(ScatteringTorch1D, TimeFrequencyScatteringBas
 
         S = timefrequency_scattering(x, self.backend.pad, self.backend.unpad,
                                      self.backend, self.J, self.J_fr, self.psi1_f, 
-                                     self.psi2_f, self.phi_f, self.sc_freq, 
+                                     self.psi2_f, self.phi_f,
+                                     self.sc_freq.psi1_f, self.sc_freq.phi_f, 
                                      pad_left=self.pad_left, pad_right=self.pad_right,
                                      ind_start=self.ind_start, ind_end=self.ind_end,
                                      oversampling=self.oversampling,
                                      size_scattering=size_scattering,
                                      out_type=self.out_type)
+        scattering_shape = S.shape[-3:]
+        new_shape = batch_shape + scattering_shape
+        S = S.reshape(new_shape)
 
         return S
 

--- a/kymatio/scattering1d/frontend/torch_frontend.py
+++ b/kymatio/scattering1d/frontend/torch_frontend.py
@@ -3,6 +3,7 @@ import warnings
 
 from ...frontend.torch_frontend import ScatteringTorch
 from ..core.scattering1d import scattering1d
+from ..core.timefrequency_scattering import timefrequency_scattering
 from ..utils import precompute_size_scattering
 from .base_frontend import ScatteringBase1D, TimeFrequencyScatteringBase
 
@@ -144,12 +145,6 @@ class ScatteringTorch1D(ScatteringTorch, ScatteringBase1D):
 
 ScatteringTorch1D._document()
 
-
-def timefrequency_scattering(x, pad, unpad, backend, J, J_fr, psi1, psi2, phi, 
-                             psi_fr, pad_left=0,pad_right=0, ind_start=None, 
-                             ind_end=None, oversampling=0, size_scattering=(0, 0, 0), 
-                             out_type='array'):
-    pass
 
 
 class TimeFrequencyScatteringTorch(ScatteringTorch1D, TimeFrequencyScatteringBase):


### PR DESCRIPTION
This pull request adds the core algorithm of JTFS. This is, of course, a work in progress. Correctness is definitely not guaranteed. 

For an input of shape `2x512`, output is of shape `2x49x4x8`, where the `8` is time dimension, `4` is frequency, `49` is the number of jtfs coefficents (I would appreciate it if those in the know could define this more specifically for me). 

This algorithm is only implemented for `T, F = None`. I will slowly add in the other options as we review. 

This PR utilized Vincent Lostanlen's original WIP implementation of the joint time frequency scattering transform, located [here](https://github.com/janden/kymatio/tree/vincent_jtfs).

@rastegah are you able to visualize the coefficients and see if this implementation is correct? Once we're able to visualize lets debug a bit and then bring notice of this PR to Vincent on Friday/next Monday. 